### PR TITLE
use scala 2.10.0 in akka-examples

### DIFF
--- a/2.2/async/akka-examples/project/build.scala
+++ b/2.2/async/akka-examples/project/build.scala
@@ -9,7 +9,7 @@ object AkkaExamplesBuild extends Build {
   val Organization = "com.example"
   val Name = "Akka Examples"
   val Version = "0.1.0-SNAPSHOT"
-  val ScalaVersion = "2.9.2"
+  val ScalaVersion = "2.10.0"
   val ScalatraVersion = "2.2.1"
 
   lazy val project = Project (

--- a/2.2/async/akka-examples/src/main/scala/com/example/app/MyActorApp.scala
+++ b/2.2/async/akka-examples/src/main/scala/com/example/app/MyActorApp.scala
@@ -3,7 +3,7 @@ package com.example.app
 import akka.actor.{ActorRef, Actor, Props, ActorSystem}
 import akka.util.Timeout
 import org.scalatra.{FutureSupport, Accepted, ScalatraServlet}
-import akka.dispatch.ExecutionContext
+import scala.concurrent.ExecutionContext
 
 class MyActorApp(system:ActorSystem, myActor:ActorRef) extends ScalatraServlet with FutureSupport {
 

--- a/2.2/async/akka-examples/src/main/scala/com/example/app/PageRetriever.scala
+++ b/2.2/async/akka-examples/src/main/scala/com/example/app/PageRetriever.scala
@@ -1,18 +1,20 @@
 package com.example.app
 
-import _root_.akka.actor.ActorSystem
-import _root_.akka.dispatch.{Future, ExecutionContext}
-import _root_.akka.dispatch.{Promise => AkkaPromise}
-
+import akka.actor.ActorSystem
+import scala.concurrent.{Future, Promise, ExecutionContext}
 import dispatch._
 import org.scalatra._
+import scala.util.{Left, Try}
 
 object DispatchAkka {
 
   def retrievePage()(implicit ctx: ExecutionContext): Future[String] = {
-    val prom = AkkaPromise[String]()
+    val prom = Promise[String]()
     dispatch.Http(url("http://slashdot.org/") OK as.String) onComplete {
-      case r => prom.complete(r)
+      case r => r match {
+        case Left(exception) => println(exception)
+        case Right(content) => prom.complete(Try{content})
+      }
     }
     prom.future
   }


### PR DESCRIPTION
Updated scala to use 2.10.0. 

Migrated code based on http://doc.akka.io/docs/akka/2.1.2/project/migration-guide-2.0.x-2.1.x.html.
