### PR TITLE
add system.properties file to use Java 7 on Heroku

### DIFF
--- a/2.3/deployment/scalatra-heroku/system.properties
+++ b/2.3/deployment/scalatra-heroku/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=1.7


### PR DESCRIPTION
From the Heroku docs:

> By default, Java apps run on OpenJDK 6. However, it’s possible to run on newer versions of the JVM.

From the Scalatra 2.3 change log:

> Breaking: Require java 7

It's possible to specify which JDK to use on Heroku by including a simple system.properties file in the base folder of a Scalatra project - i've added one to this sample to use Java 7.

Without it, this sample would deploy but crash when running - with it, it works.

As referenced in #12 the README is also out of date for using 2.3 with Heroku - i will set some time aside next week to fix it up.
