### PR TITLE
Update build.scala

### DIFF
--- a/2.4/swagger-example/project/build.scala
+++ b/2.4/swagger-example/project/build.scala
@@ -15,7 +15,7 @@ object FlowershopBuild extends Build {
   lazy val project = Project (
     "flowershop",
     file("."),
-    settings = Defaults.defaultSettings ++ ScalatraPlugin.scalatraWithJRebel ++ scalateSettings ++ Seq(
+    settings = ScalatraPlugin.scalatraWithJRebel ++ scalateSettings ++ Seq(
       organization := Organization,
       name := Name,
       version := Version,


### PR DESCRIPTION
Default settings are now defined in AutoPlugins
Starting in 0.13.2 the `Defaults.defaultSettings` method is deprecated, and all default settings are contributed to projects via AutoPlugins.  Sbt core provides three out of the box plugins:  sbt.plugins.GlobalModule, sbt.plugins.IvyModule, sbt.plugins.JvmModule.