### PR TITLE
Artifactory SaaS servers has been shut down. 

### DIFF
--- a/2.4/http/scalatra-http-demo/sbt
+++ b/2.4/http/scalatra-http-demo/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -168,7 +168,7 @@ sbt_groupid () {
 sbt_artifactory_list () {
   local version0=$(sbt_version)
   local version=${version0%-SNAPSHOT}
-  local url="http://typesafe.artifactoryonline.com/typesafe/ivy-snapshots/$(sbt_groupid)/sbt-launch/"
+  local url="http://repo.typesafe.com/typesafe/ivy-snapshots/$(sbt_groupid)/sbt-launch/"
   dlog "Looking for snapshot list at: $url "
 
   curl -s --list-only "$url" | \
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi


### PR DESCRIPTION
After Typesafe migrated both repo.typesafe.com and repo.scala-sbt.org to JFrog Bintray, SaaS servers has been shut down. It's better to use the proxy URL https://repo.typesafe.com and https://repo.scala-sbt.org instead of where they redirect.  https://www.typesafe.com/blog/incident-report-for-repo-typesafe-com-and-repo-scala-sbt-org