### PR TITLE
Download sbt-launch from repo.typesafe.com

### DIFF
--- a/2.4/async/akka-examples/sbt
+++ b/2.4/async/akka-examples/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/async/scalatra-atmosphere-embedded/sbt
+++ b/2.4/async/scalatra-atmosphere-embedded/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/async/scalatra-atmosphere-example/sbt
+++ b/2.4/async/scalatra-atmosphere-example/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/deployment/scalatra-heroku/sbt
+++ b/2.4/deployment/scalatra-heroku/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/deployment/scalatra-jelastic/sbt
+++ b/2.4/deployment/scalatra-jelastic/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/formats/scalatra-commands/sbt
+++ b/2.4/formats/scalatra-commands/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/http/authentication-demo/sbt
+++ b/2.4/http/authentication-demo/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/http/scalatra-gzip/sbt
+++ b/2.4/http/scalatra-gzip/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/http/scalatra-http-client/sbt
+++ b/2.4/http/scalatra-http-client/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/http/scentry-auth-demo/sbt
+++ b/2.4/http/scentry-auth-demo/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/persistence/riak-example/sbt
+++ b/2.4/persistence/riak-example/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/persistence/scalatra-casbah-example/sbt
+++ b/2.4/persistence/scalatra-casbah-example/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/persistence/scalatra-slick/sbt
+++ b/2.4/persistence/scalatra-slick/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/persistence/scalatra-squeryl/sbt
+++ b/2.4/persistence/scalatra-squeryl/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -222,7 +222,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/resources/scalatra-coffeescript/sbt
+++ b/2.4/resources/scalatra-coffeescript/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/resources/scalatra-less-css/sbt
+++ b/2.4/resources/scalatra-less-css/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi

--- a/2.4/swagger-example/sbt
+++ b/2.4/swagger-example/sbt
@@ -102,7 +102,7 @@ make_url () {
   category="$2"
   version="$3"
 
-  echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
+  echo "http://repo.typesafe.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
@@ -216,7 +216,7 @@ download_url () {
 
   mkdir -p $(dirname "$jar") && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl -L --fail --silent "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi


### PR DESCRIPTION
sbt-launch.jar is no longer available from artifactory. This (hopefully) updates all the sbt scripts that haven't been changed yet.