### PR TITLE
Fixed to wait for db.run exit surely

### DIFF
--- a/2.6/persistence/scalatra-slick/src/main/scala/org/scalatra/slickexample/SlickApp.scala
+++ b/2.6/persistence/scalatra-slick/src/main/scala/org/scalatra/slickexample/SlickApp.scala
@@ -78,13 +78,15 @@ trait SlickRoutes extends ScalatraBase with FutureSupport {
   def db: Database
 
   get("/db/create-db") {
-    db.run(Tables.createDatabase)
+    val f = db.run(Tables.createDatabase)
+    Await.result(f, Duration.Inf)
 
     "created database"
   }
 
   get("/db/drop-db") {
-    db.run(Tables.dropSchemaAction)
+    val f = db.run(Tables.dropSchemaAction)
+    Await.result(f, Duration.Inf)
     
     "dropped database"
   }

--- a/2.6/persistence/scalatra-slick/src/main/scala/org/scalatra/slickexample/SlickApp.scala
+++ b/2.6/persistence/scalatra-slick/src/main/scala/org/scalatra/slickexample/SlickApp.scala
@@ -78,21 +78,14 @@ trait SlickRoutes extends ScalatraBase with FutureSupport {
   def db: Database
 
   get("/db/create-db") {
-    val f = db.run(Tables.createDatabase)
-    Await.result(f, Duration.Inf)
-
-    "created database"
+    db.run(Tables.createDatabase)
   }
 
   get("/db/drop-db") {
-    val f = db.run(Tables.dropSchemaAction)
-    Await.result(f, Duration.Inf)
-    
-    "dropped database"
+    db.run(Tables.dropSchemaAction)
   }
 
   get("/coffees") {
-    contentType = "text/plain"
     db.run(Tables.findCoffeesWithSuppliers.result) map { xs =>
       println(xs)
       xs map { case (s1, s2) => f"  $s1 supplied by $s2" } mkString "\n"


### PR DESCRIPTION
This caused travis to fail

The returned value of db.run returns Future,
but since it was generating the result without
waiting for completion, 'await' surely waited for it.